### PR TITLE
fix(test): test an advanced package.json version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@marlondc/greeting-test",
-  "version": "1.1.1",
+  "version": "2.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@marlondc/greeting-test",
-  "version": "1.1.1",
+  "version": "2.1.0",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Test if an advanced package.json version works. Artificially changed package.json version to 2.1.0 when currently on npm it's 1.1.1.

The expected behaviour is the version will go to 1.1.2 in both npm and package.json.