### PR TITLE
feat(test no release): update version so release is ahead of npm as test

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "publishConfig": {
     "access": "public"
   },
+  "private": true,
   "release": {
     "branches": "main",
     "plugins": [


### PR DESCRIPTION
Test

Releasing without publish to see what happens to cause out of sync versions to see what happens.

Currently both versions are 1.1.2